### PR TITLE
Disable listening to SIGWINCH on NT

### DIFF
--- a/src/cdsetool/cli.py
+++ b/src/cdsetool/cli.py
@@ -1,6 +1,8 @@
 """
 Command line interface
 """
+import os
+import sys
 import json as JSON
 from typing import List, Optional
 from typing_extensions import Annotated
@@ -47,7 +49,7 @@ def query_search(
     """
     search_term = search_term or []
     search_term = _to_dict(search_term)
-    features = query_features(collection, {**search_term})
+    features = query_features(collection, search_term)
 
     for feature in features:
         if json:
@@ -75,9 +77,13 @@ def download(
     """
     Download all features matching the search terms
     """
+    if not os.path.exists(path):
+        print(f"Path {path} does not exist")
+        sys.exit(1)
+
     search_term = search_term or []
     search_term = _to_dict(search_term)
-    features = query_features(collection, {**search_term})
+    features = query_features(collection, search_term)
 
     list(
         download_features(

--- a/src/cdsetool/monitor.py
+++ b/src/cdsetool/monitor.py
@@ -13,7 +13,7 @@ import sys
 import os
 import signal
 
-LINE_LENGTH, _ = os.get_terminal_size()
+LINE_LENGTH = 80
 
 
 def _set_line_length(_signal_num, _stack):
@@ -21,7 +21,11 @@ def _set_line_length(_signal_num, _stack):
     LINE_LENGTH, _ = os.get_terminal_size()
 
 
-signal.signal(signal.SIGWINCH, _set_line_length)
+_set_line_length(None, None)
+
+# handle sigwinch on linux
+if os.name != "nt":
+    signal.signal(signal.SIGWINCH, _set_line_length)
 
 
 class StatusMonitor(threading.Thread):

--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -17,7 +17,7 @@ class FeatureQuery:
 
     def __init__(self, collection, search_terms):
         self.features = []
-        self.next_url = _query_url(collection, {search_terms})
+        self.next_url = _query_url(collection, search_terms)
 
     def __iter__(self):
         return self


### PR DESCRIPTION
Windows does not support `Signal.signal(signal.SIGWINCH, handler)`, so we disable it entirely

fixes #3