### PR TITLE
validate search terms by pattern

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,9 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-    permissions:
-      pull-requests: write
-      contents: write
+    permissions: write-all
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,9 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-
+    permissions:
+      pull-requests: write
+      contents: write
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,4 +28,9 @@ jobs:
         pip install -e .[test]
     - name: Test with pytest
       run: |
-        pytest
+        pytest --cov=cdsetool --cov-report xml
+    - name: Python Coverage
+      uses: orgoro/coverage@v3.1
+      with:
+          coverageFile: coverage.xml
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/
 
 env/
 __pycache__/
+
+.coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
 test = [
     "black==23.11.0",
     "pylint==3.0.2",
-    "pytest==7.4.3"
+    "pytest==7.4.3",
+    "pytest-cov==4.1.0",
 ]
 
 [project.urls]

--- a/src/cdsetool/cli.py
+++ b/src/cdsetool/cli.py
@@ -27,8 +27,18 @@ def query_search_terms(collection: str):
     """
     print(f"Available search terms for collection {collection}:")
     # TODO: print validators
-    for key, _ in describe_collection(collection).items():
-        print(f"\t- {key}")
+    for key, attributes in describe_collection(collection).items():
+        print(f"  - {key}")
+        if attributes.get("title"):
+            print(f"    - Description: {attributes.get('title')}")
+        if attributes.get("pattern"):
+            print(f"    - Pattern: {attributes.get('pattern')}")
+        if attributes.get("minInclusive"):
+            print(f"    - Min: {attributes.get('minInclusive')}")
+        if attributes.get("maxInclusive"):
+            print(f"    - Max: {attributes.get('maxInclusive')}")
+
+        print()
 
 
 # TODO: implement limit

--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -5,8 +5,8 @@ https://documentation.dataspace.copernicus.eu/APIs/OpenSearch.html
 """
 from xml.etree import ElementTree
 from datetime import datetime, date
-import requests
 import re
+import requests
 
 
 class FeatureQuery:
@@ -86,10 +86,10 @@ def describe_collection(collection):
 
         if name:
             parameters[name] = {
-                    "pattern": pattern,
-                    "minInclusive": min_inclusive,
-                    "maxInclusive": max_inclusive,
-                    "title": title,
+                "pattern": pattern,
+                "minInclusive": min_inclusive,
+                "maxInclusive": max_inclusive,
+                "title": title,
             }
 
     return parameters
@@ -122,41 +122,47 @@ def _serialize_search_term(search_term):
 
     return str(search_term)
 
+
 def _validate_search_term(key, search_term, description):
+    _assert_valid_key(key, description)
+    _assert_match_pattern(search_term, description.get(key).get("pattern"))
+    _assert_min_inclusive(search_term, description.get(key).get("minInclusive"))
+    _assert_max_inclusive(search_term, description.get(key).get("maxInclusive"))
+
+
+def _assert_valid_key(key, description):
     assert key in description.keys(), (
         f'search_term with name "{key}" '
-        + f'was not found for collection.'
+        + "was not found for collection."
         + f" Available terms are: {', '.join(description.keys())}"
     )
 
-    _validate_pattern(search_term, description[key]["pattern"])
-    _validate_min_inclusive(search_term, description[key]["minInclusive"])
-    _validate_max_inclusive(search_term, description[key]["maxInclusive"])
 
-
-def _validate_pattern(search_term, pattern):
+def _assert_match_pattern(search_term, pattern):
     if not pattern:
         return
 
-    assert re.match(pattern, search_term), (
-        f"search_term {search_term} does not match pattern {pattern}"
-    )
+    assert re.match(
+        pattern, search_term
+    ), f"search_term {search_term} does not match pattern {pattern}"
 
-def _validate_min_inclusive(search_term, min_inclusive):
+
+def _assert_min_inclusive(search_term, min_inclusive):
     if not min_inclusive:
         return
 
-    assert search_term >= min_inclusive, (
-        f"search_term {search_term} is less than min_inclusive {min_inclusive}"
-    )
+    assert (
+        search_term >= min_inclusive
+    ), f"search_term {search_term} is less than min_inclusive {min_inclusive}"
 
-def _validate_max_inclusive(search_term, max_inclusive):
+
+def _assert_max_inclusive(search_term, max_inclusive):
     if not max_inclusive:
         return
 
-    assert search_term <= max_inclusive, (
-        f"search_term {search_term} is greater than max_inclusive {max_inclusive}"
-    )
+    assert (
+        search_term <= max_inclusive
+    ), f"search_term {search_term} is greater than max_inclusive {max_inclusive}"
 
 
 _describe_docs = {}

--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -6,6 +6,7 @@ https://documentation.dataspace.copernicus.eu/APIs/OpenSearch.html
 from xml.etree import ElementTree
 from datetime import datetime, date
 import requests
+import re
 
 
 class FeatureQuery:
@@ -65,12 +66,43 @@ def shape_to_wkt(shape):
     )
 
 
+def describe_collection(collection):
+    """
+    Get a list of valid options for a given collection in key value pairs
+    """
+    content = _get_describe_doc(collection)
+    tree = ElementTree.fromstring(content)
+    parameter_node_parent = tree.find(
+        "{http://a9.com/-/spec/opensearch/1.1/}Url[@type='application/json']"
+    )
+
+    parameters = {}
+    for parameter_node in parameter_node_parent:
+        name = parameter_node.attrib.get("name")
+        pattern = parameter_node.attrib.get("pattern")
+        min_inclusive = parameter_node.attrib.get("minInclusive")
+        max_inclusive = parameter_node.attrib.get("maxInclusive")
+        title = parameter_node.attrib.get("title")
+
+        if name:
+            parameters[name] = {
+                    "pattern": pattern,
+                    "minInclusive": min_inclusive,
+                    "maxInclusive": max_inclusive,
+                    "title": title,
+            }
+
+    return parameters
+
+
 def _query_url(collection, search_terms):
-    _validate_search_terms(collection, search_terms)
+    description = describe_collection(collection)
 
     query_list = []
     for key, value in search_terms.items():
-        query_list.append(f"{key}={_serialize_search_term(value)}")
+        val = _serialize_search_term(value)
+        _validate_search_term(key, val, description)
+        query_list.append(f"{key}={val}")
 
     return (
         "https://catalogue.dataspace.copernicus.eu"
@@ -90,36 +122,41 @@ def _serialize_search_term(search_term):
 
     return str(search_term)
 
-
-def _validate_search_terms(collection, search_terms):
-    description = describe_collection(collection)
-    keys = description.keys()
-    for key in search_terms.keys():
-        assert key in keys, (
-            f'search_term with name "{key}" '
-            + f'was not found for collection "{collection}".'
-            + f" Available terms are: {', '.join(keys)}"
-        )
-        # TODO: validate patterns, minInclude, maxInclusive
-
-
-def describe_collection(collection):
-    """
-    Get a list of valid options for a given collection in key value pairs
-    """
-    content = _get_describe_doc(collection)
-    tree = ElementTree.fromstring(content)
-    parameter_node_parent = tree.find(
-        "{http://a9.com/-/spec/opensearch/1.1/}Url[@type='application/json']"
+def _validate_search_term(key, search_term, description):
+    assert key in description.keys(), (
+        f'search_term with name "{key}" '
+        + f'was not found for collection.'
+        + f" Available terms are: {', '.join(description.keys())}"
     )
 
-    parameters = {}
-    for parameter_node in parameter_node_parent:
-        name = parameter_node.attrib.get("name")
-        if name:
-            parameters[name] = True  # TODO: replace with available options
+    _validate_pattern(search_term, description[key]["pattern"])
+    _validate_min_inclusive(search_term, description[key]["minInclusive"])
+    _validate_max_inclusive(search_term, description[key]["maxInclusive"])
 
-    return parameters
+
+def _validate_pattern(search_term, pattern):
+    if not pattern:
+        return
+
+    assert re.match(pattern, search_term), (
+        f"search_term {search_term} does not match pattern {pattern}"
+    )
+
+def _validate_min_inclusive(search_term, min_inclusive):
+    if not min_inclusive:
+        return
+
+    assert search_term >= min_inclusive, (
+        f"search_term {search_term} is less than min_inclusive {min_inclusive}"
+    )
+
+def _validate_max_inclusive(search_term, max_inclusive):
+    if not max_inclusive:
+        return
+
+    assert search_term <= max_inclusive, (
+        f"search_term {search_term} is greater than max_inclusive {max_inclusive}"
+    )
 
 
 _describe_docs = {}

--- a/tests/query_test.py
+++ b/tests/query_test.py
@@ -1,6 +1,13 @@
 import pytest
 
-from cdsetool.query import _serialize_search_term
+from cdsetool.query import (
+    _serialize_search_term,
+    _validate_search_term,
+    _assert_match_pattern,
+    _assert_valid_key,
+    _assert_min_inclusive,
+    _assert_max_inclusive,
+)
 from datetime import date, datetime
 
 
@@ -11,3 +18,75 @@ def test_serialize_search_term():
     assert (
         _serialize_search_term(datetime(2020, 1, 1, 12, 0, 0)) == "2020-01-01T12:00:00Z"
     )
+
+
+def test_validate_search_term():
+    description = {
+        "productType": {"pattern": "^(S2MSI1C|S2MSI2A)$"},
+        "orbitNumber": {
+            "minInclusive": "1",
+            "pattern": "^(\\[|\\]|[0-9])?[0-9]+$|^[0-9]+?(\\[|\\])$|^(\\[|\\])[0-9]+,[0-9]+(\\[|\\])$",
+        },
+    }
+    _validate_search_term("productType", "S2MSI1C", description)
+    _validate_search_term("orbitNumber", "1", description)
+    _validate_search_term("orbitNumber", "43212", description)
+
+    with pytest.raises(AssertionError):
+        _validate_search_term("productType", "foo", description)
+
+    with pytest.raises(AssertionError):
+        _validate_search_term("orbitNumber", "0", description)
+
+    with pytest.raises(AssertionError):
+        _validate_search_term("orbitNumber", "-100", description)
+
+    with pytest.raises(AssertionError):
+        _validate_search_term("orbitNumber", "foobar", description)
+
+
+def test_assert_valid_key():
+    _assert_valid_key("someKey", {"someKey": True})
+
+    with pytest.raises(AssertionError):
+        _assert_valid_key("otherKey", {"someKey": True})
+
+
+def test_assert_match_pattern():
+    pattern = "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?(|Z|[\\+\\-][0-9]{2}:[0-9]{2}))?$"
+
+    with pytest.raises(AssertionError):
+        _assert_match_pattern("foo", pattern)
+
+    with pytest.raises(AssertionError):
+        _assert_match_pattern("01-01-2020", pattern)
+
+    _assert_match_pattern("2020-01-01", pattern)
+    _assert_match_pattern("2020-01-01T20:31:28.888Z", pattern)
+
+    pattern = "^(asc|desc|ascending|descending)$"
+
+    with pytest.raises(AssertionError):
+        _assert_match_pattern("foo", pattern)
+
+    with pytest.raises(AssertionError):
+        _assert_match_pattern("01-01-2020", pattern)
+
+    _assert_match_pattern("asc", pattern)
+    _assert_match_pattern("descending", pattern)
+
+
+def test_assert_min_inclusive():
+    _assert_min_inclusive(1, 1)
+    _assert_min_inclusive(2, 1)
+
+    with pytest.raises(AssertionError):
+        _assert_min_inclusive(0, 1)
+
+
+def test_assert_max_inclusive():
+    _assert_max_inclusive(1, 1)
+    _assert_max_inclusive(0, 1)
+
+    with pytest.raises(AssertionError):
+        _assert_max_inclusive(2, 1)

--- a/tests/query_test.py
+++ b/tests/query_test.py
@@ -61,6 +61,7 @@ def test_assert_match_pattern():
     with pytest.raises(AssertionError):
         _assert_match_pattern("01-01-2020", pattern)
 
+    _assert_match_pattern("2020-01-01", None)
     _assert_match_pattern("2020-01-01", pattern)
     _assert_match_pattern("2020-01-01T20:31:28.888Z", pattern)
 


### PR DESCRIPTION
The `describe.xml` endpoint provides a number of different patterns to validate parameters by. This PR aims to implement this validation.

Currently only `pattern`, `minInclusive` and `maxInclusive` are being validated.
Its possible to validate options too, but some options are seemingly only examples and not exhaustive, which makes this impractical. An example would be [Sentinel2](https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel2/describe.xml) only providing 5 `tileId`, when many more are available in actuality.