### PR TITLE
implement a single frontend class for wrapping download and query

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,15 +71,14 @@ pip install cdsetool==0.1.3
 ### Querying features
 
 Querying is always done in batches, returning `len(results) <= maxRecords` records each time.
-A local buffer is filled and gradually emptied as results are yielded. When the buffer is empty,
-more results will be requested and the process repeated until no more results are available, or
-the iterator is discarded.
+Results are stored in an iterable for future use, and will only query the server when the result
+is absent from the local dataset.
 
 Since downloading features is the most common use-case, `query_features` assumes that the query will run till the end.
 Because of this, the batch size is set to `2000`, which is the size limit set by CDSE.
 
 ```python
-from cdsetool.query import query_features
+from cdsetool import CDSETool
 
 collection = "Sentinel2"
 search_terms = {
@@ -88,15 +87,18 @@ search_terms = {
     "processingLevel": "S2MSI1C"
 }
 
+cdse = CDSETool()
+query = cdse.query(collection, search_terms)
+
 # wait for a single batch to finish, yield results immediately
-for feature in query_features(collection, search_terms):
+for feature in query:
     # do something with feature
 
 # wait for all batch requests to complete, returning list
-features = list(query_features(collection, search_terms))
+features = list(query)
 
 # manually iterate
-iter = query_features(collection, search_terms)
+iter = iter(query)
 
 featureA = next(iter)
 featureB = next(iter)
@@ -247,9 +249,12 @@ for feature in features:
 - [X] Query schema validation
 - [ ] High-level API
     - [ ] Query features
+        - [X] Query by search terms
+        - [ ] Validation of date ranges
+        - [ ] Automatic conversion to WKT
     - [ ] Download features
         - [ ] Download single feature
-        - [ ] Download list of features
+        - [X] Download list of features
         - [ ] Download by ID
         - [ ] Download by URL
 - [ ] Command-Line Interface

--- a/src/cdsetool/__init__.py
+++ b/src/cdsetool/__init__.py
@@ -1,0 +1,36 @@
+from cdsetool.query import query_features
+from cdsetool.credentials import Credentials
+from cdsetool.download import download_features
+from cdsetool.monitor import StatusMonitor
+
+
+class CDSETool:
+    """
+    A class for querying and downloading data from the Copernicus Data Space Ecosystem
+    """
+
+    def __init__(self, **options):
+        self.options = options
+
+    def query(self, collection, search_terms=None):
+        """
+        Query the Copernicus Data Space Ecosystem OpenSearch API
+        """
+        search_terms = search_terms or {}
+        return query_features(collection, search_terms)
+
+    def download(self, downloadable, path):
+        """
+        Download features from a Copernicus Data Space Ecosystem OpenSearch API result
+        """
+        options = {"credentials": self._credentials()}
+        if self.options.get("progress", True):
+            options["monitor"] = StatusMonitor
+        return list(download_features(downloadable, path, options=options))
+
+    def _credentials(self):
+        return Credentials(
+            self.options.get("username"),
+            self.options.get("password"),
+            self.options.get("token_endpoint"),
+        )

--- a/src/cdsetool/credentials.py
+++ b/src/cdsetool/credentials.py
@@ -24,12 +24,18 @@ class Credentials:  # pylint: disable=too-few-public-methods disable=too-many-in
         self,
         username=None,
         password=None,
-        token_endpoint="https://identity.dataspace.copernicus.eu"
-        + "/auth/realms/CDSE/protocol/openid-connect/token",
+        token_endpoint=None,
     ):
         self.__username = username
         self.__password = password
-        self.__token_endpoint = token_endpoint
+        self.__token_endpoint = (
+            token_endpoint
+            or "https://identity.dataspace.copernicus.eu/auth/realms/CDSE/protocol/openid-connect/token"
+        )
+
+        print(self.__username)
+        print(self.__password)
+        print(self.__token_endpoint)
 
         self.__access_token = None
         self.__refresh_token = None

--- a/src/cdsetool/download.py
+++ b/src/cdsetool/download.py
@@ -6,6 +6,8 @@ all features in a result set.
 """
 import os
 import random
+import re
+import shutil
 import tempfile
 import time
 from cdsetool._processing import _concurrent_process
@@ -19,9 +21,11 @@ def download_feature(feature, path, options=None):
 
     Returns the feature ID
     """
+    _ensure_path(path)
+
     options = options or {}
     url = _get_feature_url(feature)
-    filename = feature.get("properties").get("title")
+    filename = feature.get("properties").get("title").replace(".SAFE", ".zip")
 
     if not url or not filename:
         return feature.get("id")
@@ -50,7 +54,7 @@ def download_feature(feature, path, options=None):
                 status.add_progress(len(chunk))
 
         os.close(fd)
-        os.rename(tmp, os.path.join(path, filename.replace(".SAFE", ".zip")))
+        shutil.move(tmp, os.path.join(path, filename))
 
     return feature.get("id")
 
@@ -96,3 +100,9 @@ def _retry_backoff(url, session):
         response = session.get(url, stream=True)
 
     return response
+
+
+def _ensure_path(path):
+    if not os.path.exists(path):
+        os.makedirs(path)
+    return path

--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -32,7 +32,7 @@ class _FeatureIterator:
 
 class FeatureQuery:
     """
-    An iterator over the features matching the search terms
+    An iterable over the features matching the search terms
 
     Queries the API in batches (default: 50) features, and returns them one by one.
     Queries the next batch when the current batch is exhausted.
@@ -82,7 +82,7 @@ class FeatureQuery:
 
 def query_features(collection, search_terms):
     """
-    Returns an iterator over the features matching the search terms
+    Returns an iterable of features matching the search terms
     """
     return FeatureQuery(collection, {"maxRecords": 2000, **search_terms})
 


### PR DESCRIPTION
CDSETool does not currently have a lot of quality of life features, such as validation of order of dates. 
This PR attempts to wrap the underlying functions into a single class, while adding these features for ease of use.

The underlying methods will remain relatively untouched for the more advanced use-cases