### PR TITLE
dependabot: use for Github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Add the github-actions package-ecosystem
to dependabot so CI actions are kept
up to date.

Actions aren't typically updated multiple
times per week, so run the check on a daily
basis.