### PR TITLE
Make geojson_to_wkt function handle single-feature FeatureCollections.

### DIFF
--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -114,6 +114,8 @@ def geojson_to_wkt(geojson):
 
     if geojson.get("type") == "Feature":
         geojson = geojson["geometry"]
+    elif geojson.get("type") == "FeatureCollection" and len(geojson["features"]) == 1:
+        geojson = geojson["features"][0]["geometry"]
 
     coordinates = str(
         tuple(item for sublist in geojson["coordinates"][0] for item in sublist)


### PR DESCRIPTION
Minor change for geojson_to_wkt.

The motivation for this change is to make geojson_to_wkt work with single-feature FeatureCollections geojson files. A quite common way of creating geojson files of AOI's is by using the geojson.io webpage, which defaults to FeatureCollection even for one feature.