### PR TITLE
Add optional logging

### DIFF
--- a/src/cdsetool/logger.py
+++ b/src/cdsetool/logger.py
@@ -1,0 +1,26 @@
+"""
+Logging utilities.
+
+This module provides a NoopLogger class that outputs nothing.
+"""
+
+
+class NoopLogger:
+    """
+    A logger that does nothing.
+    """
+
+    def debug(self, *kwargs):
+        """
+        Log a debug message.
+        """
+
+    def info(self, *kwargs):
+        """
+        Log an info message.
+        """
+
+    def warning(self, *kwargs):
+        """
+        Log a warning message.
+        """

--- a/tests/logger/logger_test.py
+++ b/tests/logger/logger_test.py
@@ -1,0 +1,41 @@
+import pytest
+from unittest.mock import MagicMock
+
+from cdsetool.logger import NoopLogger
+from cdsetool.download import download_feature
+
+
+def test_noop_logger_is_default():
+    NoopLogger.debug = MagicMock()
+
+    assert NoopLogger.debug.call_count == 0
+
+    download_feature(
+        {
+            "bad_object": True,
+            "properties": {
+                "title": "myfile.xml",
+                "services": {"download": {}},  # missing url
+            },
+        },
+        "somewhere",
+    )
+
+    assert NoopLogger.debug.call_count == 1
+
+
+def test_noop_does_not_error():
+    try:
+        download_feature(
+            {
+                "bad_object": True,
+                "properties": {
+                    "title": "myfile.xml",
+                    "services": {"download": {}},  # missing url
+                },
+            },
+            "somewhere",
+        )
+        NoopLogger.debug("NoopLogger did not raise an exception")
+    except Exception as e:
+        pytest.fail(f"Unexpected exception: {e}")


### PR DESCRIPTION
This adds support for clients to pass in
a configured logger object to get warning
logs on retries, and debug logs in general
when downloading.

The default logger is a no-op logger, so
default behavior remains unchanged.