### PR TITLE
download: use existing open fd

### DIFF
--- a/src/cdsetool/download.py
+++ b/src/cdsetool/download.py
@@ -47,7 +47,7 @@ def download_feature(feature, path, options=None):
         status.set_filesize(content_length)
 
         fd, tmp = tempfile.mkstemp()  # pylint: disable=invalid-name
-        with open(tmp, "wb") as file:
+        with open(fd, "wb") as file:
             for chunk in response.iter_content(chunk_size=1024 * 1024 * 5):
                 if not chunk:
                     continue
@@ -55,7 +55,6 @@ def download_feature(feature, path, options=None):
                 file.write(chunk)
                 status.add_progress(len(chunk))
 
-        os.close(fd)
         shutil.move(tmp, result_path)
 
     return feature.get("id")


### PR DESCRIPTION
Use the existing open file descriptor
instead of opening a new file descriptor
to the same file.

It is not clear to me if this has any
bearing for #67, but having fewer file
descriptors open will not make anything
worse.