### PR TITLE
download: write all received bytes to file

### DIFF
--- a/src/cdsetool/download.py
+++ b/src/cdsetool/download.py
@@ -51,9 +51,6 @@ def download_feature(feature, path, options=None):
         fd, tmp = tempfile.mkstemp()  # pylint: disable=invalid-name
         with open(fd, "wb") as file:
             for chunk in response.iter_content(chunk_size=1024 * 1024 * 5):
-                if not chunk:
-                    continue
-
                 file.write(chunk)
                 status.add_progress(len(chunk))
 


### PR DESCRIPTION
This is what `stream_response_to_file` from the requests toolbelt package does, and that package resides alongside the requests package on Github.

Refs #67