### PR TITLE
download: return error on failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ test = [
 [project.scripts]
 cdsetool = "cdsetool:cli.main"
 
+[tool.pylint.design]
+max-locals = 20
+
 [tool.pylint.format]
 max-line-length = "88"
 disable="fixme"

--- a/src/cdsetool/download.py
+++ b/src/cdsetool/download.py
@@ -25,13 +25,14 @@ def download_feature(feature, path, options=None):
     options = options or {}
     log = _get_logger(options)
     url = _get_feature_url(feature)
-    filename = feature.get("properties").get("title")
+    title = feature.get("properties").get("title")
 
-    if not url or not filename:
-        log.debug(f"Bad URL ('{url}') or filename ('{filename}')")
+    if not url or not title:
+        log.debug(f"Bad URL ('{url}') or title ('{title}')")
         return feature.get("id")
 
-    result_path = os.path.join(path, filename.replace(".SAFE", ".zip"))
+    filename = title.replace(".SAFE", ".zip")
+    result_path = os.path.join(path, filename)
 
     if not options.get("overwrite_existing", False) and os.path.exists(result_path):
         log.debug(f"File {result_path} already exists, skipping..")

--- a/src/cdsetool/download.py
+++ b/src/cdsetool/download.py
@@ -29,14 +29,14 @@ def download_feature(feature, path, options=None):
 
     if not url or not title:
         log.debug(f"Bad URL ('{url}') or title ('{title}')")
-        return feature.get("id")
+        return None
 
     filename = title.replace(".SAFE", ".zip")
     result_path = os.path.join(path, filename)
 
     if not options.get("overwrite_existing", False) and os.path.exists(result_path):
         log.debug(f"File {result_path} already exists, skipping..")
-        return feature.get("id")
+        return filename
 
     with _get_monitor(options).status() as status:
         status.set_filename(filename)
@@ -60,7 +60,7 @@ def download_feature(feature, path, options=None):
 
         shutil.move(tmp, result_path)
 
-    return feature.get("id")
+    return filename
 
 
 def download_features(features, path, options=None):


### PR DESCRIPTION
First commit renames some variables as preparation
for the second commit.

The second commit updates download_feature
to return None when it fails, and the filename
downloaded when it succeeds.

Fixes #59 