### PR TITLE
proxy feature on query and download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .coverage
-
+environment
+main.py
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/src/cdsetool/download.py
+++ b/src/cdsetool/download.py
@@ -120,7 +120,7 @@ def _get_monitor(options):
 def _get_credentials(options):
     return options.get("credentials") or Credentials()
 
-def _set_proxy(options,session):
+def _set_proxy(options, session):
     proxies = options.get("proxies", {})
     if proxies != {}:
         session.proxies.update(proxies)

--- a/src/cdsetool/download.py
+++ b/src/cdsetool/download.py
@@ -42,7 +42,7 @@ def download_feature(feature, path, options=None):
         status.set_filename(filename)
 
         session = _get_credentials(options).get_session()
-        session = _set_proxy(options,session) # here set the proxy
+        session = _set_proxy(options, session)  # here set the proxy
         url = _follow_redirect(url, session)
         response = _retry_backoff(url, session, options)
 
@@ -119,6 +119,7 @@ def _get_monitor(options):
 
 def _get_credentials(options):
     return options.get("credentials") or Credentials()
+
 
 def _set_proxy(options, session):
     proxies = options.get("proxies", {})

--- a/src/cdsetool/download.py
+++ b/src/cdsetool/download.py
@@ -42,6 +42,7 @@ def download_feature(feature, path, options=None):
         status.set_filename(filename)
 
         session = _get_credentials(options).get_session()
+        session = _set_proxy(options,session) # here set the proxy
         url = _follow_redirect(url, session)
         response = _retry_backoff(url, session, options)
 
@@ -118,3 +119,9 @@ def _get_monitor(options):
 
 def _get_credentials(options):
     return options.get("credentials") or Credentials()
+
+def _set_proxy(options,session):
+    proxies = options.get("proxies", {})
+    if proxies != {}:
+        session.proxies.update(proxies)
+    return session

--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -42,10 +42,12 @@ class FeatureQuery:
 
     total_results = None
 
-    def __init__(self, collection, search_terms, proxies = {}):
+    def __init__(self, collection, search_terms, proxies={}):
         self.features = []
         self.proxies = proxies
-        self.next_url = _query_url(collection, {**search_terms, "exactCount": "1"}, proxies)
+        self.next_url = _query_url(
+            collection, {**search_terms, "exactCount": "1"}, proxies
+        )
 
     def __iter__(self):
         return _FeatureIterator(self)
@@ -228,14 +230,15 @@ def _assert_max_inclusive(search_term, max_inclusive):
 _describe_docs = {}
 
 
-def _get_describe_doc(collection, proxies = {}):
+def _get_describe_doc(collection, proxies={}):
     if _describe_docs.get(collection):
         return _describe_docs.get(collection)
 
     res = requests.get(
         "https://catalogue.dataspace.copernicus.eu"
         + f"/resto/api/collections/{collection}/describe.xml",
-        timeout=120, proxies=proxies
+        timeout=120,
+        proxies=proxies,
     )
     assert res.status_code == 200, (
         f"Unable to find collection with name {collection}. Please see "

--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -42,10 +42,10 @@ class FeatureQuery:
 
     total_results = None
 
-    def __init__(self, collection, search_terms,proxies = {}):
+    def __init__(self, collection, search_terms, proxies = {}):
         self.features = []
         self.proxies = proxies
-        self.next_url = _query_url(collection, {**search_terms, "exactCount": "1"},proxies)
+        self.next_url = _query_url(collection, {**search_terms, "exactCount": "1"}, proxies)
 
     def __iter__(self):
         return _FeatureIterator(self)
@@ -64,7 +64,7 @@ class FeatureQuery:
 
     def __fetch_features(self):
         if self.next_url is not None:
-            res = requests.get(self.next_url, timeout=120,proxies=self.proxies).json()
+            res = requests.get(self.next_url, timeout=120, proxies=self.proxies).json()
             self.features += res.get("features") or []
 
             total_results = res.get("properties", {}).get("totalResults")
@@ -126,11 +126,11 @@ def geojson_to_wkt(geojson):
     return f"POLYGON({paired_coord})"
 
 
-def describe_collection(collection,proxies):
+def describe_collection(collection, proxies):
     """
     Get a list of valid options for a given collection in key value pairs
     """
-    content = _get_describe_doc(collection,proxies)
+    content = _get_describe_doc(collection, proxies)
     tree = ElementTree.fromstring(content)
     parameter_node_parent = tree.find(
         "{http://a9.com/-/spec/opensearch/1.1/}Url[@type='application/json']"
@@ -155,8 +155,8 @@ def describe_collection(collection,proxies):
     return parameters
 
 
-def _query_url(collection, search_terms,proxies):
-    description = describe_collection(collection,proxies)
+def _query_url(collection, search_terms ,proxies):
+    description = describe_collection(collection, proxies)
 
     query_list = []
     for key, value in search_terms.items():
@@ -228,14 +228,14 @@ def _assert_max_inclusive(search_term, max_inclusive):
 _describe_docs = {}
 
 
-def _get_describe_doc(collection,proxies = {}):
+def _get_describe_doc(collection, proxies = {}):
     if _describe_docs.get(collection):
         return _describe_docs.get(collection)
 
     res = requests.get(
         "https://catalogue.dataspace.copernicus.eu"
         + f"/resto/api/collections/{collection}/describe.xml",
-        timeout=120,proxies=proxies
+        timeout=120, proxies=proxies
     )
     assert res.status_code == 200, (
         f"Unable to find collection with name {collection}. Please see "

--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -155,7 +155,7 @@ def describe_collection(collection, proxies):
     return parameters
 
 
-def _query_url(collection, search_terms ,proxies):
+def _query_url(collection, search_terms, proxies):
     description = describe_collection(collection, proxies)
 
     query_list = []

--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -85,11 +85,11 @@ class FeatureQuery:
             self.next_url = self.next_url.replace("exactCount=1", "exactCount=0")
 
 
-def query_features(collection, search_terms):
+def query_features(collection, search_terms, proxies=None):
     """
     Returns an iterator over the features matching the search terms
     """
-    return FeatureQuery(collection, {"maxRecords": 2000, **search_terms})
+    return FeatureQuery(collection, {"maxRecords": 2000, **search_terms}, proxies)
 
 
 def shape_to_wkt(shape):

--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -42,7 +42,7 @@ class FeatureQuery:
 
     total_results = None
 
-    def __init__(self, collection, search_terms, proxies={}):
+    def __init__(self, collection, search_terms, proxies=None):
         self.features = []
         self.proxies = proxies
         self.next_url = _query_url(
@@ -230,10 +230,9 @@ def _assert_max_inclusive(search_term, max_inclusive):
 _describe_docs = {}
 
 
-def _get_describe_doc(collection, proxies={}):
+def _get_describe_doc(collection, proxies=None):
     if _describe_docs.get(collection):
         return _describe_docs.get(collection)
-
     res = requests.get(
         "https://catalogue.dataspace.copernicus.eu"
         + f"/resto/api/collections/{collection}/describe.xml",

--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -46,7 +46,7 @@ class FeatureQuery:
         self.features = []
         self.proxies = proxies
         self.next_url = _query_url(
-            collection, {**search_terms, "exactCount": "1"}, proxies
+            collection, {**search_terms, "exactCount": "1"}, proxies=proxies
         )
 
     def __iter__(self):
@@ -128,11 +128,11 @@ def geojson_to_wkt(geojson):
     return f"POLYGON({paired_coord})"
 
 
-def describe_collection(collection, proxies):
+def describe_collection(collection, proxies=None):
     """
     Get a list of valid options for a given collection in key value pairs
     """
-    content = _get_describe_doc(collection, proxies)
+    content = _get_describe_doc(collection, proxies=proxies)
     tree = ElementTree.fromstring(content)
     parameter_node_parent = tree.find(
         "{http://a9.com/-/spec/opensearch/1.1/}Url[@type='application/json']"
@@ -157,8 +157,8 @@ def describe_collection(collection, proxies):
     return parameters
 
 
-def _query_url(collection, search_terms, proxies):
-    description = describe_collection(collection, proxies)
+def _query_url(collection, search_terms, proxies=None):
+    description = describe_collection(collection, proxies=proxies)
 
     query_list = []
     for key, value in search_terms.items():


### PR DESCRIPTION
Hello, I have made the changes just for the proxy feature, it can be used it the following way:

```Python
proxies = {'http': 'http_proxy', 'https': 'https_proxy'}

features = query_features(
    "Sentinel1",
    {
        "startDate": "2020-12-20",
        "completionDate": date(2020, 12, 25),
        "processingLevel": "LEVEL1",
        "sensorMode": "IW",
        "productType": "IW_GRDH_1S",
        "geometry": shape_to_wkt("path/to/shapefile.shp"),
    },
    proxies
)

list(
    download_features(
        features,
        "path/to/output/folder/",
        {
            "concurrency": 4,
            "monitor": StatusMonitor(),
            "credentials": Credentials("username", "password"),
            "proxies": proxies,
        },
    )
)
```

I tried to add the proxy to all the requests in the query and added the proxy in the session object in the download part, let me know if it work this time.
if the fields of proxies are not passed in the query and download it should work as it was before.