### PR TITLE
credentials: timestamp before post

### DIFF
--- a/src/cdsetool/credentials.py
+++ b/src/cdsetool/credentials.py
@@ -99,8 +99,8 @@ class Credentials:  # pylint: disable=too-few-public-methods disable=too-many-in
         self.__token_exchange(data)
 
     def __token_exchange(self, data):
-        response = requests.post(self.__token_endpoint, data=data, timeout=120)
         now = datetime.now()
+        response = requests.post(self.__token_endpoint, data=data, timeout=120)
 
         if response.status_code == 401:
             raise InvalidCredentialsException(


### PR DESCRIPTION
Performing the post takes some time,
so be more pessimistic in token expiration
time and calculate it from a time
before post.

This hopefully reduces the number
of ExpiredSignatureError thrown when
calling download_feature.