### PR TITLE
credentials: inline private methods

### DIFF
--- a/tests/credentials/credentials_test.py
+++ b/tests/credentials/credentials_test.py
@@ -148,7 +148,7 @@ def test_ensure_tokens(requests_mock, mocker):
     credentials._Credentials__access_token_expires = (
         datetime.datetime.now() - datetime.timedelta(hours=100)
     )
-    spy = mocker.spy(credentials, "_Credentials__refresh_access_token")
+    spy = mocker.spy(credentials, "_Credentials__token_exchange")
     credentials._Credentials__ensure_tokens()
     spy.assert_called_once()
 
@@ -158,9 +158,8 @@ def test_ensure_tokens(requests_mock, mocker):
     credentials._Credentials__refresh_token_expires = (
         datetime.datetime.now() - datetime.timedelta(hours=100)
     )
-    spy = mocker.spy(credentials, "_Credentials__exchange_credentials")
     credentials._Credentials__ensure_tokens()
-    spy.assert_called_once()
+    assert spy.call_count == 2
 
 
 def test_read_credentials(requests_mock, mocker):
@@ -197,8 +196,9 @@ def test_refresh_token(requests_mock, mocker):
     _mock_token(requests_mock)  # mock again to return a new token
 
     prev_access_token = credentials._Credentials__access_token
-    credentials._Credentials__access_token = None
-    credentials._Credentials__refresh_access_token()
+    credentials._Credentials__access_token_expires = datetime.datetime.now()
+    credentials._Credentials__refresh_token_expires = datetime.datetime.now()
+    credentials._Credentials__ensure_tokens()
 
     assert credentials._Credentials__access_token is not None
     assert credentials._Credentials__refresh_token is not None


### PR DESCRIPTION
Initialize the expire times for credentials to a time, and inline a few single-use methods that are private to the class. This saves almost 50 lines of code and reduces the surface area of the Credentials object while preserving existing functionality.