### PR TITLE
download: inline single-use variable

### DIFF
--- a/src/cdsetool/download.py
+++ b/src/cdsetool/download.py
@@ -53,9 +53,7 @@ def download_feature(feature, path, options=None):
                     time.sleep(60 * (1 + (random.random() / 4)))
                     continue
 
-                content_length = int(response.headers["Content-Length"])
-
-                status.set_filesize(content_length)
+                status.set_filesize(int(response.headers["Content-Length"]))
 
                 with open(fd, "wb") as file:
                     for chunk in response.iter_content(chunk_size=1024 * 1024 * 5):


### PR DESCRIPTION
There is no need for an intermediate
variable, pass the file size directly
to the monitor.