### PR TITLE
Fix: Edge-case futures are not filling above water level

### DIFF
--- a/src/cdsetool/_processing.py
+++ b/src/cdsetool/_processing.py
@@ -14,25 +14,45 @@ def _concurrent_process(fun, iterable, workers=4):
 
     Returns an iterable of the results
     """
+
+    # Futures are submitted in batches instead of all at once to avoid
+    # requesting too many items from the iterable at once, which is important if
+    # the iterable is a generator that is producing items on the fly.
+    #
+    # The 1.5 factor is a small overhead to keep jobs > workers at all times, instead
+    # of jobs == workers, which could cause the workers to be idle while waiting for
+    # the iterable to produce more items.
     low_water_mark = int(workers * 1.5)
     iterator = iter(iterable)
 
     with ThreadPoolExecutor(max_workers=workers) as executor:
         futures = []
 
+        # Pluck an item from the iterable and submit it to the executor.
+        # If the iterable is exhausted, this function is a no-op.
         def submit_item():
             item = next(iterator, None)
             if item is not None:
                 futures.append(executor.submit(fun, item))
 
-        for _ in range(low_water_mark):
-            submit_item()
+        # Fill the futures list up to the low water mark
+        def fill_futures():
+            for _ in range(low_water_mark - len(futures)):
+                submit_item()
 
+        # Submit the first batch of items
+        fill_futures()
+
+        # Continue until no more futures are queued
         while futures:
+
+            # Wait for the first future(s) to complete
             done, futures = wait(futures, return_when=FIRST_COMPLETED)
             futures = list(futures)
+
+            # Yield the results of the completed futures
             for future in done:
                 yield future.result()
 
-            if len(futures) < low_water_mark:
-                submit_item()
+            # Submit items to replace the ones that are done.
+            fill_futures()


### PR DESCRIPTION
Fix possible edge-case race condition as per discussion here https://github.com/SDFIdk/CDSETool/pull/101#issuecomment-1997824538

Futures are now always filled above `low_water_mark`, as the return value of `wait` with `FIRST_COMPLETED` is not guaranteed to have `len(done) == 1`

Also add comments to explain convoluted async code