### PR TITLE
download: retry token connection errors

### DIFF
--- a/src/cdsetool/credentials.py
+++ b/src/cdsetool/credentials.py
@@ -50,6 +50,12 @@ class TokenExchangeException(Exception):
     """
 
 
+class TokenClientConnectionError(Exception):
+    """
+    Raised when token connection fails.
+    """
+
+
 class Credentials:  # pylint: disable=too-few-public-methods disable=too-many-instance-attributes
     """
     A class for handling credentials for the Copernicus Identity
@@ -165,7 +171,10 @@ class Credentials:  # pylint: disable=too-few-public-methods disable=too-many-in
                         "client_id": "cdse-public",
                     }
                 self.__token_exchange(data)
-            key = self.__jwk_client.get_signing_key_from_jwt(self.__access_token)
+            try:
+                key = self.__jwk_client.get_signing_key_from_jwt(self.__access_token)
+            except jwt.PyJWKClientConnectionError as e:
+                raise TokenClientConnectionError from e
             jwt.decode(
                 self.__access_token,
                 key=key.key,

--- a/src/cdsetool/download.py
+++ b/src/cdsetool/download.py
@@ -11,7 +11,7 @@ import tempfile
 import time
 import shutil
 from cdsetool._processing import _concurrent_process
-from cdsetool.credentials import Credentials
+from cdsetool.credentials import Credentials, TokenClientConnectionError
 from cdsetool.logger import NoopLogger
 from cdsetool.monitor import NoopMonitor
 
@@ -44,7 +44,11 @@ def download_feature(feature, path, options=None):
         attempts = 0
         while attempts < 5:
             # Always get a new session, credentials might have expired.
-            session = _get_credentials(options).get_session()
+            try:
+                session = _get_credentials(options).get_session()
+            except TokenClientConnectionError as e:
+                log.warning(e)
+                continue
             url = _follow_redirect(url, session)
             with session.get(url, stream=True) as response:
                 if response.status_code != 200:


### PR DESCRIPTION
PyJWT might throw an exception on connection
error, so wrap that into our own exception
so download can retry without token implementation details leaking into download.