### PR TITLE
query: check return value of get

### DIFF
--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -65,15 +65,16 @@ class FeatureQuery:
         return self.features[index]
 
     def __fetch_features(self):
-        if self.next_url is not None:
-            res = requests.get(self.next_url, timeout=120, proxies=self.proxies).json()
-            self.features += res.get("features") or []
+        if self.next_url is None:
+            return
+        res = requests.get(self.next_url, timeout=120, proxies=self.proxies).json()
+        self.features += res.get("features") or []
 
-            total_results = res.get("properties", {}).get("totalResults")
-            if total_results is not None:
-                self.total_results = total_results
+        total_results = res.get("properties", {}).get("totalResults")
+        if total_results is not None:
+            self.total_results = total_results
 
-            self.__set_next_url(res)
+        self.__set_next_url(res)
 
     def __set_next_url(self, res):
         links = res.get("properties", {}).get("links") or []

--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -67,14 +67,16 @@ class FeatureQuery:
     def __fetch_features(self):
         if self.next_url is None:
             return
-        res = requests.get(self.next_url, timeout=120, proxies=self.proxies).json()
-        self.features += res.get("features") or []
+        with requests.get(self.next_url, timeout=120, proxies=self.proxies) as response:
+            response.raise_for_status()
+            res = response.json()
+            self.features += res.get("features") or []
 
-        total_results = res.get("properties", {}).get("totalResults")
-        if total_results is not None:
-            self.total_results = total_results
+            total_results = res.get("properties", {}).get("totalResults")
+            if total_results is not None:
+                self.total_results = total_results
 
-        self.__set_next_url(res)
+            self.__set_next_url(res)
 
     def __set_next_url(self, res):
         links = res.get("properties", {}).get("links") or []


### PR DESCRIPTION
The request might not succeed, in
which case the json() call will
give a mysterious:

json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

Do a .raise_for_status() before
calling json() on the response.
This also throws an exception
in the face of the user,
but it's easier to understand
that something went wrong
with the HTTP request.