### PR TITLE
dependabot: run on a daily basis

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
I was trying to update to typer 0.10, but CDSETool dependencies are blocking that. Run dependabot on a daily basis so pull requests are generated "immediately" on a release.