### PR TITLE
credentials: ask oidc-config for signing algos

### DIFF
--- a/src/cdsetool/credentials.py
+++ b/src/cdsetool/credentials.py
@@ -178,7 +178,7 @@ class Credentials:  # pylint: disable=too-few-public-methods disable=too-many-in
             jwt.decode(
                 self.__access_token,
                 key=key.key,
-                algorithms=key._algorithms,  # pylint: disable=protected-access
+                algorithms=self.__id_token_signing_algos,
                 options={"verify_aud": False},
             )
 
@@ -210,6 +210,10 @@ class Credentials:  # pylint: disable=too-few-public-methods disable=too-many-in
     @property
     def __jwks_uri(self):
         return self.__openid_configuration["jwks_uri"]
+
+    @property
+    def __id_token_signing_algos(self):
+        return self.__openid_configuration["id_token_signing_alg_values_supported"]
 
     @property
     def __jwk_client(self):


### PR DESCRIPTION
The pyjwt manual advises against looking at the token for deciding the valid algorithms, so use the OIDC-example from the manual instead.