### PR TITLE
CI: use anchors for branches

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,9 +2,10 @@ name: Pytest
 
 on:
   push:
-    branches: [ "main" ]
+    branches: &branches
+      - "main"
   pull_request:
-    branches: [ "main" ]
+    branches: *branches
 
 permissions: {}
 


### PR DESCRIPTION
The path lists are meant to be identical,
so use the new yaml anchors to ensure that.