### PR TITLE
dependabot: group action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      actions-deps:
+        patterns:
+          - "*"


### PR DESCRIPTION
With the actions pinned to the exact
version, there are a lot of updates.
I don't think I have seen any action
update fail the CI in this repository,
so group the updates into a single
weekly PR.